### PR TITLE
Add Docker Support

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,90 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  release:
+    types: [published]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.13.1'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -72,6 +72,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.11-slim
+
+ENV PYTHONFAULTHANDLER=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=random \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100 \
+    POETRY_VERSION=1.3.2
+
+# System deps:
+RUN pip install "poetry==$POETRY_VERSION"
+RUN apt-get -y update
+RUN apt-get install -y ffmpeg
+
+# Copy only requirements to cache them in docker layer
+WORKDIR /code
+COPY pyproject.toml ./
+
+# Project initialization:
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi
+
+# Creating folders, and files for a project:
+COPY selfhostNoReplitDB.py ./
+COPY docker-entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+# Change this env var with your discord token
+ENV token ""
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TikTok Auto Embed for Discord
-Discord Bot that downloads and embeds tiktok links sent by users
+Discord Bot that downloads and embeds tiktok links sent by users.
 
 The TikTok Auto Embed bot will automatically embed the tiktoks links you send. This is helpful because your friends can now watch the tiktoks you send without leaving the app. When you post a TikTok link, the TikTok Auto Embed bot will delete your original message and send a new message containing: the original link, the sender's discord tag, and an embedded copy of the video.
 
@@ -18,3 +18,15 @@ https://tinyurl.com/TiktokAutoEmbed
 
 
 Thanks to https://github.com/thedtvn for helping with the webscraping code.
+
+## Docker
+To run on Docker, pull the image using the following command:
+```
+docker pull ghcr.io/dumax315/tiktok-auto-embed:latest
+```
+Then, run the container with the following command:
+```
+docker run ghcr.io/dumax315/tiktok-auto-embed:latest -e token=YOURDISCORDTOKEN
+```
+> **Warning**
+> You may want to use a version tag instead of latest. See this repo's GitHub releases page for available versions.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "Starting Bot..."
+echo "Token: $token"
+if [[ -n "$token" ]]
+then
+    python /code/selfhostNoReplitDB.py
+else
+    echo "TOKEN IS REQUIRED"
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["theohalpern <<>>"]
 python = "^3.8"
 flask = "^2.0.1"
 pyppeteer = "^0.2.5"
-"discord.py" = "^1.7.2"
+"discord.py" = "^2.1.1"
 replit = "^3.1.0"
 
 [tool.poetry.dev-dependencies]

--- a/selfhostNoReplitDB.py
+++ b/selfhostNoReplitDB.py
@@ -127,7 +127,7 @@ async def get(text):
                   cookies = session.cookie_jar.filter_cookies('https://www.tiktok.com')
 
                   jar = {}
-                  for key, cookie in cookies.items():
+                  for cookie in cookies.items():
                     # print('Key: "%s", Value: "%s"' % (cookie.key, cookie.value))
                     jar[cookie.key] = cookie.value
                   # print(jar)
@@ -380,7 +380,7 @@ async def on_message(message):
         print("failed after download")
       except:
         print(message.content)
-        print("faild never downloaded")
+        print("failed never downloaded")
       try:
         await toEdit.delete()
       except:


### PR DESCRIPTION
Adds support for building docker images.

### Changes:
- Fixed spelling error
- Added dockerfile and docker-entrypoint script
- Added GitHub Action to automatically build and publish the image to GHCR when a release is published
- Bump `discord.py` version

### Usage:

**Actions**: 
The GitHub action requires no pre-configuration. It will automatically request the tokens from GitHub to publish to GHCR.
Simply create a release on GitHub and the action will be triggered to build the image and publish it.

**Docker**:
1. Pull the image. Ex: `docker pull ghcr.io/bman46/tiktok-auto-embed:latest`
2. Run the image. Ex: `docker run -e token=yourtoken ghcr.io/bman46/tiktok-auto-embed:latest`